### PR TITLE
Bugs/#6 check nodes before create cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,19 @@
 language: python
 python: "2.7.13"
 sudo: required
-language: python
+
 services:
   - docker
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y software-properties-common
-  - sudo apt-add-repository -y ppa:ansible/ansible
-  - sudo apt-get update
-  - sudo apt-get install -y ansible python-pip python-dev libffi-dev libssl-dev libxml2-dev libxslt1-dev libjpeg8-dev zlib1g-dev
 install:
-  - sudo pip install molecule
-  - sudo pip install docker
+  - pip install ansible==2.3.1.0
+  - pip install molecule==1.25.0
+  - pip install docker
 script:
   - pushd tests/single-mode
-  - travis_wait 30 sudo molecule test
+  - travis_wait 30 molecule test
   - popd
   - pushd tests/cluster-mode
-  - travis_wait 40 sudo molecule test
+  - travis_wait 40 molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ install:
 script:
   - pushd tests/single-mode
   - travis_wait 30 molecule test
-  - popd
-  - pushd tests/cluster-mode
-  - travis_wait 40 molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ install:
 script:
   - pushd tests/single-mode
   - travis_wait 30 sudo molecule test
+  - popd
+  - pushd tests/cluster-mode
+  - travis_wait 40 sudo molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Use in a playbook:
 
 Look to the [defaults](defaults/main.yml) properties file to see the possible configuration properties.
 
+There is a playbook and example configuration on [cluster mode test](tests/cluster-mode). This role have been testing to deploy a cluster provisioning host one by one.
+
 ## Testing
 
 ### Testing cluster mode

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -11,4 +11,3 @@
 - name: REDIS | Configure nodes as cluster
   command: "{{ redis_conf_path }}/cluster-creator.sh"
   when: redis_mode == 'cluster' and (redis_is_installed == False or redis_install_new_version == True)
-  run_once: True

--- a/templates/cluster-creator.sh.j2
+++ b/templates/cluster-creator.sh.j2
@@ -1,11 +1,32 @@
 #!/bin/bash
 
-# redis doesnt accept hostname as cluster members https://github.com/antirez/redis/pull/2323
-{% for host in ansible_play_batch %}
-IPS="$IPS {{ hostvars[host]['ansible_default_ipv4']['address'] }}" # {{ host }}
-{% endfor %}
-
 PORT={{ redis_confs.port }}
+HOSTS="{{ ansible_play_hosts  | join(' ') }}"
+
+COUNT_NODES=0
+COUNT_PONGS=0
+
+for HOST in $HOSTS; do
+    COUNT_NODES=$(($COUNT_NODES+1))
+    PONG=$(redis-cli -h $HOST -p $PORT PING)
+    if [ "$PONG" == "PONG" ]; then
+        COUNT_PONGS=$((COUNT_PONGS+1))
+    fi
+done
+
+if [ "$COUNT_PONGS" != "$COUNT_NODES" ]; then
+    echo "Waiting nodes..."
+    exit 0
+fi
+
+# redis doesnt accept hostname as cluster members https://github.com/antirez/redis/pull/2323
+for HOST in $HOSTS; do
+    IP=$(host $HOST | grep address  | cut -d" " -f4)
+    IPS="$IPS $IP"
+done
+
+
+
 {% if redis_cluster_replicas != 0 %}
 REPLICAS="--replicas {{ redis_cluster_replicas }}"
 {% endif %}

--- a/tests/cluster-mode/goss/specs/redis.yml
+++ b/tests/cluster-mode/goss/specs/redis.yml
@@ -40,3 +40,9 @@ service:
   redis-server:
     enabled: true
     running: true
+
+command:
+  redis-cli PING:
+    exit-status: 0
+    stdout:
+      - PONG

--- a/tests/cluster-mode/group_vars/redis.yml
+++ b/tests/cluster-mode/group_vars/redis.yml
@@ -8,9 +8,9 @@ redis_confs:
   bind: "0.0.0.0"
   protected-mode: "no"
   port: "6379" # this is mandatory
-  pidfile: "/conf/redis/redis.pid"
+  pidfile: "{{ redis_conf_path }}/redis.pid"
   loglevel: "notice"
-  logfile: "/var/log/redis.log"
+  logfile: "{{ redis_log_path }}/redis.log"
   databases: "16"
   rdbcompression: "yes"
   rdbchecksum: "yes"

--- a/tests/cluster-mode/playbook.yml
+++ b/tests/cluster-mode/playbook.yml
@@ -1,5 +1,6 @@
 ---
 
 - hosts: redis
+  serial: 1
   roles:
     - redis-role

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-redis_required_libs: ["tcl"]
+redis_required_libs: ["tcl", "host"]
 redis_required_libs_cluster: ["ruby"]
 
 redis_source_url: http://download.redis.io/releases/redis-{{ redis_version }}.tar.gz


### PR DESCRIPTION
I have added a check on cluster creator script to count the number of nodes that are up, with this, we can verify if the cluster nodes are ready before invoke redis-trib create command.

This solution is the better way to make a cluster deploy but it limits us to run the role in more than one host at a time, so I included a line on README _Usage_ section that explains this and reference the cluster mode test playbook.

I have added a verification on goss file that run "ping" command on local redis server. 