### PR TITLE
Features/#8 manage cluster restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,23 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/redis-role/tree/develop)
 
+## [2.1.0](https://github.com/idealista/redis-role/tree/2.1.0) (2017-08-16)
+[Full Changelog](https://github.com/idealista/redis-role/compare/2.0.1...2.1.0)
+
+### Added
+- *[#8](https://github.com/idealista/redis-role/issues/8) Add `upgrading-helper` script to manage nodes during cluster upgrades* @jdvr
+
 ## [2.0.1](https://github.com/idealista/redis-role/tree/2.0.0) (2017-08-10)
 [Full Changelog](https://github.com/idealista/redis-role/compare/2.0.0...2.0.1)
 
-###Fixed
+### Fixed
 - *[#4](https://github.com/idealista/redis-role/issues/4) Remove redis group from `cluster-creator` script* @jdvr
 - *[#6](https://github.com/idealista/redis-role/issues/6) Check nodes status before create cluster* @jdvr
 
 ## [2.0.0](https://github.com/idealista/redis-role/tree/2.0.0) (2017-08-10)
 [Full Changelog](https://github.com/idealista/redis-role/compare/1.0.0...2.0.0)
 
-###Added
+### Added
 - *[#1](https://github.com/idealista/redis-role/issues/1) Redis cluster (install nodes and configure)* @jdvr
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/redis-role/tree/develop)
 
-## [2.1.0](https://github.com/idealista/redis-role/tree/2.1.0) (2017-08-16)
+## [2.1.0](https://github.com/idealista/redis-role/tree/2.1.0) (2017-08-17)
 [Full Changelog](https://github.com/idealista/redis-role/compare/2.0.1...2.1.0)
 
 ### Added

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,8 +6,3 @@
     state: restarted
 
   when: redis_service_state != 'stopped'
-
-- name: stop redis
-  service:
-    name: redis-server
-    state: stopped

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,3 +6,8 @@
     state: restarted
 
   when: redis_service_state != 'stopped'
+
+- name: stop redis
+  service:
+    name: redis-server
+    state: stopped

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -44,5 +44,4 @@
     - cluster-config.sh
     - cluster-creator.sh
     - upgrading-helper.sh
-  notify: restart redis
   when: redis_mode == 'cluster'

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -35,10 +35,14 @@
 
 - name: REDIS | Copy cluster creator
   template:
-    src: cluster-creator.sh.j2
-    dest: "{{ redis_conf_path }}/cluster-creator.sh"
+    src: "{{ item }}.j2"
+    dest: "{{ redis_conf_path }}/{{ item }}"
     owner: "{{ redis_user }}"
     group: "{{ redis_group }}"
     mode: 0755
+  with_items:
+    - cluster-config.sh
+    - cluster-creator.sh
+    - upgrading-helper.sh
   notify: restart redis
   when: redis_mode == 'cluster'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -31,11 +31,18 @@
   when: redis_is_installed == false and redis_confs.logfile is defined
 
 
-- name: REDIS | Remove install folder if redis is not installed
+- name: REDIS | Remove instance from cluster
+  command: "{{ redis_conf_path }}/upgrading-helper.sh delete"
+  notify: stop redis
+  when:
+    - redis_install_new_version == true
+    - redis_mode == 'cluster'
+
+- name: REDIS | Remove existing install folder
   file:
     state: absent
     path: "{{ redis_install_path }}"
-  when: redis_is_installed == false
+  when: redis_is_installed == false or redis_install_new_version == true
 
 - name: REDIS | install required libs
   apt:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,6 +38,14 @@
     - redis_install_new_version == true
     - redis_mode == 'cluster'
 
+- name: REDIS | Stop node
+  service:
+    name: redis-server
+    state: stopped
+  when:
+    - redis_install_new_version == true
+    - redis_mode == 'cluster'
+
 - name: REDIS | Remove existing install folder
   file:
     state: absent

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,7 +33,6 @@
 
 - name: REDIS | Remove instance from cluster
   command: "{{ redis_conf_path }}/upgrading-helper.sh delete"
-  notify: stop redis
   when:
     - redis_install_new_version == true
     - redis_mode == 'cluster'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -10,4 +10,12 @@
 
 - name: REDIS | Configure nodes as cluster
   command: "{{ redis_conf_path }}/cluster-creator.sh"
-  when: redis_mode == 'cluster' and (redis_is_installed == False or redis_install_new_version == True)
+  when:
+    - redis_mode == 'cluster'
+    - redis_is_installed == False
+
+- name: REDIS | Add instance to cluster
+  command: "{{ redis_conf_path }}/upgrading-helper.sh add"
+  when:
+    - redis_install_new_version == true
+    - redis_mode == 'cluster'

--- a/templates/cluster-config.sh.j2
+++ b/templates/cluster-config.sh.j2
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
 PORT={{ redis_confs.port }}
-CURRENT_HOST={{ inventory_hostname }}
+CURRENT_HOST="{{ inventory_hostname }}"
+NODE_IP="{{ hostvars[inventory_hostname].ansible_default_ipv4.address }}:$PORT"
 HOSTS="{{ ansible_play_hosts  | join(' ') }}"
 {% if redis_cluster_replicas != 0 %}
 REPLICAS="--replicas {{ redis_cluster_replicas }}"
 {% endif %}
 REDIS_PATH={{ redis_install_path }}
 REDIS_CONF={{ redis_conf_path }}
-NODE_CONF_FILE={{ redis_confs.cluster-config-file }}
-alias redis-trib=$REDIS_PATH/src/redis-trib.rb
+NODE_CONF_FILE="node.conf"
+
+redis-trib () {
+ $REDIS_PATH/src/redis-trib.rb $@
+}

--- a/templates/cluster-config.sh.j2
+++ b/templates/cluster-config.sh.j2
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+PORT={{ redis_confs.port }}
+CURRENT_HOST={{ inventory_hostname }}
+HOSTS="{{ ansible_play_hosts  | join(' ') }}"
+{% if redis_cluster_replicas != 0 %}
+REPLICAS="--replicas {{ redis_cluster_replicas }}"
+{% endif %}
+REDIS_PATH={{ redis_install_path }}
+REDIS_CONF={{ redis_conf_path }}
+NODE_CONF_FILE={{ redis_confs.cluster-config-file }}
+alias redis-trib=$REDIS_PATH/src/redis-trib.rb

--- a/templates/cluster-creator.sh.j2
+++ b/templates/cluster-creator.sh.j2
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-PORT={{ redis_confs.port }}
-HOSTS="{{ ansible_play_hosts  | join(' ') }}"
+source "cluster-config.sh"
 
 COUNT_NODES=0
 COUNT_PONGS=0
@@ -25,17 +24,10 @@ for HOST in $HOSTS; do
     IPS="$IPS $IP"
 done
 
-
-
-{% if redis_cluster_replicas != 0 %}
-REPLICAS="--replicas {{ redis_cluster_replicas }}"
-{% endif %}
-REDIS_PATH={{ redis_install_path }}
-
 HOSTS="";
 
 for IP in $IPS; do
   HOSTS="$HOSTS $IP:$PORT"
 done
 
-yes "yes" | $REDIS_PATH/src/redis-trib.rb create $REPLICAS $HOSTS
+yes "yes" | redis-trib create $REPLICAS $HOSTS

--- a/templates/cluster-creator.sh.j2
+++ b/templates/cluster-creator.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "cluster-config.sh"
+source "{{ redis_conf_path }}/cluster-config.sh"
 
 COUNT_NODES=0
 COUNT_PONGS=0
@@ -17,6 +17,14 @@ if [ "$COUNT_PONGS" != "$COUNT_NODES" ]; then
     echo "Waiting nodes..."
     exit 0
 fi
+
+COUNT_NODES_ON_CLUSTER=$(redis-cli -p $PORT cluster nodes | wc -l)
+
+if [ "$COUNT_NODES_ON_CLUSTER" != "1" ]; then
+    echo "Nodes already know each others..."
+    exit 0
+fi
+
 
 # redis doesnt accept hostname as cluster members https://github.com/antirez/redis/pull/2323
 for HOST in $HOSTS; do

--- a/templates/upgrading-helper.sh.j2
+++ b/templates/upgrading-helper.sh.j2
@@ -46,7 +46,7 @@ has-slave() {
 }
 
 rebalance (){
-    redis-trib rebalance $@ --use-empty-masters $NODE_IP
+    redis-trib rebalance $@ --use-empty-masters $OTHER_MASTER_IP
 }
 
 delete-node () {
@@ -63,11 +63,15 @@ delete-node () {
 }
 
 add-node () {
+    echo "Other master node ip: $OTHER_MASTER_IP"
     if is-master ; then
         redis-trib add-node $NODE_IP $OTHER_MASTER_IP
+        sleep 30 #this avoid cluster meet latency
+        redis-trib check $OTHER_MASTER_IP # this ensure every node has meet each other
         rebalance --weight $NODE_SHORT_ID=1.0
     else
         redis-trib add-node --slave $NODE_IP $OTHER_MASTER_IP
+        sleep 30
     fi
     exit 0
 }

--- a/templates/upgrading-helper.sh.j2
+++ b/templates/upgrading-helper.sh.j2
@@ -12,7 +12,7 @@ source "{{ redis_conf_path }}/cluster-config.sh"
 
 SLOTS=5461
 
-NODE_ID=$(redis-cli cluster nodes | grep myself | cut -d" " -f1)
+NODE_ID=$(redis-cli -p $PORT cluster nodes | grep myself | cut -d" " -f1)
 NODE_SHORT_ID=$(echo $NODE_ID | cut -c1-8)
 
 
@@ -26,11 +26,23 @@ for HOST in $HOSTS; do
     fi
 done
 
+slave-ip() {
+    #slave0:ip=127.0.0.1,port=7003,state=online,offset=1695,lag=1
+    return $(redis-cli -p $PORT info | grep slave0 | cut -d: -f2  | cut -d= -f2 | cut -d, -f1)
+}
 
+failover() {
+    redis-cli -h $1 -p $PORT cluster failover
+}
 
 is-master() {
     ROLE=$(redis-cli role 2> /dev/null | grep master | wc -l)
     [ "${ROLE}" == "1" ] && return 0 || return 1
+}
+
+has-slave() {
+    NO_SLAVE_LINES=$(redis-cli -p $PORT info | grep connected_slaves:0 | wc -l)
+    [ "${NO_SLAVE_LINES}" == "1" ] && return 1 || return 0
 }
 
 rebalance (){
@@ -39,17 +51,25 @@ rebalance (){
 
 delete-node () {
     if is-master ; then
-        rebalance --weight $NODE_SHORT_ID=0.0
+        if has-slave ; then
+            failover slave-ip
+        else
+            rebalance --weight $NODE_SHORT_ID=0.0
+            redis-trib del-node $OTHER_MASTER_IP $NODE_ID
+            rm $REDIS_CONF/$NODE_CONF_FILE
+        fi
     fi
-    redis-trib del-node $OTHER_MASTER_IP $NODE_ID
-    rm $REDIS_CONF/$NODE_CONF_FILE
+    exit 0
 }
 
 add-node () {
-    redis-trib add-node $NODE_IP $OTHER_MASTER_IP
     if is-master ; then
+        redis-trib add-node $NODE_IP $OTHER_MASTER_IP
         rebalance --weight $NODE_SHORT_ID=1.0
+    else
+        redis-trib add-node --slave $NODE_IP $OTHER_MASTER_IP
     fi
+    exit 0
 }
 
 declare -A commands

--- a/templates/upgrading-helper.sh.j2
+++ b/templates/upgrading-helper.sh.j2
@@ -1,53 +1,60 @@
 #!/usr/bin/env bash
 
-source "cluster-config.sh"
+
+################################################################################
+#### The porpuse of this script is to be invoked from ansible task #############
+#### You shouldn't run this manually ###########################################
+#### Variables can be change to hardcode some nodes but it is not recommended ##
+################################################################################
+
+
+source "{{ redis_conf_path }}/cluster-config.sh"
 
 SLOTS=5461
 
-set-node-id () {
-    NODE_ID=$(redis-cli cluster nodes | grep myself | cut -d" " -f1)
-}
+NODE_ID=$(redis-cli cluster nodes | grep myself | cut -d" " -f1)
+NODE_SHORT_ID=$(echo $NODE_ID | cut -c1-8)
 
-set-node-ip () {
-    NODE_IP=$(redis-cli cluster nodes | grep myself | cut -d" " -f2 | cut -d"@" -f1)
-}
 
-set-other-master-id () {
-    OTHER_MASTER_ID=$(redis-cli cluster nodes | grep master | grep -v myself | head -1 | cut -d" " -f1)
-}
+OTHER_MASTER_ID=$(redis-cli cluster nodes | grep master | grep -v myself | head -1 | cut -d" " -f1)
+OTHER_MASTER_IP=$(redis-cli cluster nodes | grep master | grep -v myself | head -1 | cut -d" " -f2 | cut -d"@" -f1)
 
-set-other-master-ip () {
-    OTHER_MASTER_IP=$(redis-cli cluster nodes | grep master | grep -v myself | head -1 | cut -d" " -f2 | cut -d"@" -f1)
-}
+for HOST in $HOSTS; do
+    if [[ -z "$OTHER_MASTER_IP" && "$CURRENT_HOST" != "$HOST"  ]]; then
+        OTHER_MASTER_ID=$(redis-cli -h $HOST -p $PORT cluster nodes | grep master | grep -v myself | head -1 | cut -d" " -f1)
+        OTHER_MASTER_IP=$(redis-cli -h $HOST -p $PORT cluster nodes | grep master | grep -v myself | head -1 | cut -d" " -f2 | cut -d"@" -f1)
+    fi
+done
+
+
 
 is-master() {
     ROLE=$(redis-cli role 2> /dev/null | grep master | wc -l)
     [ "${ROLE}" == "1" ] && return 0 || return 1
 }
 
-reshard () {
-    set-node-id
-    set-node-ip
-    set-other-master-id
-    redis-trib reshard --from $NODE_ID --to $OTHER_MASTER_ID  --slots $SLOTS --yes $NODE_IP
+rebalance (){
+    redis-trib rebalance $@ --use-empty-masters $NODE_IP
 }
 
 delete-node () {
     if is-master ; then
-        reshard
+        rebalance --weight $NODE_SHORT_ID=0.0
     fi
-    set-other-master-ip
-    set-node-id
     redis-trib del-node $OTHER_MASTER_IP $NODE_ID
     rm $REDIS_CONF/$NODE_CONF_FILE
 }
 
 add-node () {
-    set-other-master-ip
-    set-node-ip
     redis-trib add-node $NODE_IP $OTHER_MASTER_IP
+    if is-master ; then
+        rebalance --weight $NODE_SHORT_ID=1.0
+    fi
 }
 
-rebalance (){
-    redis-trib rebalance --use-empty-masters $NODE_IP
-}
+declare -A commands
+
+commands[add]=add-node
+commands[delete]=delete-node
+
+${commands[$1]}

--- a/templates/upgrading-helper.sh.j2
+++ b/templates/upgrading-helper.sh.j2
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+source "cluster-config.sh"
+
+SLOTS=5461
+
+set-node-id () {
+    NODE_ID=$(redis-cli cluster nodes | grep myself | cut -d" " -f1)
+}
+
+set-node-ip () {
+    NODE_IP=$(redis-cli cluster nodes | grep myself | cut -d" " -f2 | cut -d"@" -f1)
+}
+
+set-other-master-id () {
+    OTHER_MASTER_ID=$(redis-cli cluster nodes | grep master | grep -v myself | head -1 | cut -d" " -f1)
+}
+
+set-other-master-ip () {
+    OTHER_MASTER_IP=$(redis-cli cluster nodes | grep master | grep -v myself | head -1 | cut -d" " -f2 | cut -d"@" -f1)
+}
+
+is-master() {
+    ROLE=$(redis-cli role 2> /dev/null | grep master | wc -l)
+    [ "${ROLE}" == "1" ] && return 0 || return 1
+}
+
+reshard () {
+    set-node-id
+    set-node-ip
+    set-other-master-id
+    redis-trib reshard --from $NODE_ID --to $OTHER_MASTER_ID  --slots $SLOTS --yes $NODE_IP
+}
+
+delete-node () {
+    if is-master ; then
+        reshard
+    fi
+    set-other-master-ip
+    set-node-id
+    redis-trib del-node $OTHER_MASTER_IP $NODE_ID
+    rm $REDIS_CONF/$NODE_CONF_FILE
+}
+
+add-node () {
+    set-other-master-ip
+    set-node-ip
+    redis-trib add-node $NODE_IP $OTHER_MASTER_IP
+}
+
+rebalance (){
+    redis-trib rebalance --use-empty-masters $NODE_IP
+}


### PR DESCRIPTION
I have added a script with two simple commands _add/delete_ to operate over a node.

The script is called when `redis_install_new_version` is enabled and it choose the operation base on node role and cluster state:

* Delete a node
  * slave: *no actions*
  * master with slave: connect to to slave an trigger a [manual failover](https://redis.io/topics/cluster-tutorial#upgrading-nodes-in-a-redis-cluster)
  * master without slave: rebalance all cluster setting this node to weight 0

* Add a node
  * slave: *no actions*
  * master with slave: after the failover this node behave as a slave
  * master without slave: rebalance all cluster setting this node to weight 1 and `--use-empty-master` flag


When adding and rebalance nodes, timing is a issue I have add two commands between add and rebalance to avoid this.