### PR TITLE
 Read the main IPv4 address of a cluster host 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Fixed
 - *[#30](https://github.com/idealista/redis-role/issues/30) Read cluster config file name from configuration* @lihiwish
 
+### Fixed
+- *[#32](https://github.com/idealista/redis-role/issues/32) Reading the cluster host IP does not work well when the cluster have several IPs* @lihiwish
+
 ## [2.1.3](https://github.com/idealista/redis-role/tree/2.1.3) (2017-12-21)
 [Full Changelog](https://github.com/idealista/redis-role/compare/2.1.2...2.1.3)
 

--- a/templates/cluster-creator.sh.j2
+++ b/templates/cluster-creator.sh.j2
@@ -28,7 +28,7 @@ fi
 
 # redis doesnt accept hostname as cluster members https://github.com/antirez/redis/pull/2323
 for HOST in $HOSTS; do
-    IP=$(host $HOST | grep address  | cut -d" " -f4)
+    IP=$(getent ahostsv4 $HOST | head -1 | awk '{print $1}')
     IPS="$IPS $IP"
 done
 


### PR DESCRIPTION
The a cluster host have multiple IPs, "host" will return
several values.
If the main IP address of the cluster is IPv6,
the return value from this command will be the word "address".

Since this syntax for redis-trib does not support IPv6, this patch makes sure
we are getting the main IPv4 address of the host.

This fix #32