### PR TITLE
Fixing reading variable in dictionary redis-conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Fixed
 - *[#32](https://github.com/idealista/redis-role/issues/32) Reading the cluster host IP does not work well when the cluster have several IPs* @lihiwish
 
+### Fixed
+- *[#38](https://github.com/idealista/redis-role/issues/38) Param redis-confs.cluster-config-file is not accessed correctly* @lihiwish
+
 ## [2.1.3](https://github.com/idealista/redis-role/tree/2.1.3) (2017-12-21)
 [Full Changelog](https://github.com/idealista/redis-role/compare/2.1.2...2.1.3)
 

--- a/templates/cluster-config.sh.j2
+++ b/templates/cluster-config.sh.j2
@@ -9,7 +9,7 @@ REPLICAS="--replicas {{ redis_cluster_replicas }}"
 {% endif %}
 REDIS_PATH={{ redis_install_path }}
 REDIS_CONF={{ redis_conf_path }}
-NODE_CONF_FILE={{ redis_confs.cluster-config-file }}
+NODE_CONF_FILE={{ redis_confs['cluster-config-file'] }}
 
 redis-trib () {
  $REDIS_PATH/src/redis-trib.rb $@


### PR DESCRIPTION
Pull request https://github.com/idealista/redis-role/pull/31 introduce a bug when the accessing to
redis-confs.cluster-config-file was done incorrectly.

Since dashes are reserved characters https://github.com/ansible/ansible/issues/8849,
the accessing should be done in the "dictionary" way

This fix #38 
