### PR TITLE
Add the option to enable transparent hugepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 - *[#30](https://github.com/idealista/redis-role/issues/30) Read cluster config file name from configuration* @lihiwish
 - *[#32](https://github.com/idealista/redis-role/issues/32) Reading the cluster host IP does not work well when the cluster have several IPs* @lihiwish
 
+### Added
+- *[#36](https://github.com/idealista/redis-role/issues/36) Prevent changing transparent_hugepage for container installations* @lihiwish
+
 ## [2.1.3](https://github.com/idealista/redis-role/tree/2.1.3) (2017-12-21)
 [Full Changelog](https://github.com/idealista/redis-role/compare/2.1.2...2.1.3)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ redis_install_new_version: False  # set this to true to force an installation
 # start on boot
 redis_service_enabled: yes
 redis_log_path: "/var/log/redis"
+disable_transparent_hugepage: true  # set this to false when installing the role inside container
 
 #### redis.conf variables ####
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -65,3 +65,4 @@
 - name: REDIS | Set transparent hugepage
   shell: 'echo never > /sys/kernel/mm/transparent_hugepage/enabled'
   changed_when: false
+  when: disable_transparent_hugepage == true


### PR DESCRIPTION
When installing the redis role inside a container,
this configuration is not relevant since hugetbl cgroups doesn't let you configure it per container https://github.com/lxc/lxd/issues/2690.