### PR TITLE
Fixing running on multiple hosts

### DIFF
--- a/templates/cluster-config.sh.j2
+++ b/templates/cluster-config.sh.j2
@@ -4,6 +4,9 @@ PORT={{ redis_confs.port }}
 CURRENT_HOST="{{ inventory_hostname }}"
 NODE_IP="{{ hostvars[inventory_hostname].ansible_default_ipv4.address }}:$PORT"
 HOSTS="{{ ansible_play_hosts  | join(' ') }}"
+HOSTS_IPS="{% for h in ansible_play_hosts %}
+{{ hostvars[h]['ansible_default_ipv4']['address'] }} {% endfor %}"
+
 {% if redis_cluster_replicas != 0 %}
 REPLICAS="--replicas {{ redis_cluster_replicas }}"
 {% endif %}

--- a/templates/cluster-creator.sh.j2
+++ b/templates/cluster-creator.sh.j2
@@ -25,16 +25,10 @@ if [ "$COUNT_NODES_ON_CLUSTER" != "1" ]; then
     exit 0
 fi
 
-
-# redis doesnt accept hostname as cluster members https://github.com/antirez/redis/pull/2323
-for HOST in $HOSTS; do
-    IP=$(getent ahostsv4 $HOST | head -1 | awk '{print $1}')
-    IPS="$IPS $IP"
-done
-
 HOSTS="";
 
-for IP in $IPS; do
+# redis doesnt accept hostname as cluster members https://github.com/antirez/redis/pull/2323
+for IP in $HOSTS_IPS; do
   HOSTS="$HOSTS $IP:$PORT"
 done
 


### PR DESCRIPTION
This PL fix issue #47. It enables to read the play's hosts IP from ansible (which have the actual IPs), instead of reading the IPs from the hosts itselfs.